### PR TITLE
Resolve warning "Using 'class' keyword for protocol inheritance

### DIFF
--- a/Sources/AutoFill/OpenViewController.swift
+++ b/Sources/AutoFill/OpenViewController.swift
@@ -22,7 +22,7 @@ import MiKit
 import ExtensionKit
 import KeePassKit
 
-protocol OpenViewControllerDelegate: class {
+protocol OpenViewControllerDelegate: AnyObject {
 
     func openViewController(_ openViewController: OpenViewController, didSelect credential: Credential)
 

--- a/Sources/ExtensionKit/Database/DatabasesViewController.swift
+++ b/Sources/ExtensionKit/Database/DatabasesViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import Resources
 import MiKit
 
-public protocol DatabasesViewControllerDelegate: class {
+public protocol DatabasesViewControllerDelegate: AnyObject {
     func databasesViewController(_ databasesViewController: DatabasesViewController, didSelect database: Database)
 }
 

--- a/Sources/ExtensionKit/ExtensionDelegate.swift
+++ b/Sources/ExtensionKit/ExtensionDelegate.swift
@@ -19,7 +19,7 @@
 import Foundation
 import KeePassKit
 
-public protocol ExtensionDelegate: class {
+public protocol ExtensionDelegate: AnyObject {
 
     var extensionContext: NSExtensionContext? { get }
 

--- a/Sources/MiKee/Database/Create/CreateDatabaseViewController.swift
+++ b/Sources/MiKee/Database/Create/CreateDatabaseViewController.swift
@@ -21,7 +21,7 @@ import Resources
 import KeePassKit
 import MiKit
 
-protocol CreateDatabaseViewControllerDelegate: class {
+protocol CreateDatabaseViewControllerDelegate: AnyObject {
     func createDatabaseViewController(_ createDatabaseViewController: CreateDatabaseViewController, didCreate database: Database, tree: KPKTree?)
     func createDatabaseViewControllerDidCancel(_ createDatabaseViewController: CreateDatabaseViewController)
 }

--- a/Sources/MiKee/Database/DatabasesViewController.swift
+++ b/Sources/MiKee/Database/DatabasesViewController.swift
@@ -21,7 +21,7 @@ import Resources
 import KeePassKit
 import MiKit
 
-protocol DatabasesViewControllerDelegate: class {
+protocol DatabasesViewControllerDelegate: AnyObject {
     func databasesViewController(_ databasesViewController: DatabasesViewController, didSelect database: Database)
     func databasesViewController(_ databasesViewController: DatabasesViewController, didRemove database: Database)
 }

--- a/Sources/MiKee/Database/Key/KeysViewController.swift
+++ b/Sources/MiKee/Database/Key/KeysViewController.swift
@@ -28,7 +28,7 @@ import UIKit
 import Resources
 import MiKit
 
-public protocol KeysViewControllerDelegate: class {
+public protocol KeysViewControllerDelegate: AnyObject {
     func keysViewController(_ keysViewController: KeysViewController, didSelect key: Database.Key)
     func keysViewController(_ keysViewController: KeysViewController, didRemoveWith name: String)
 }

--- a/Sources/MiKit/UI/ActionSheet/ActionSheet.swift
+++ b/Sources/MiKit/UI/ActionSheet/ActionSheet.swift
@@ -20,7 +20,7 @@ import UIKit
 import Resources
 import ObjectiveC
 
-public protocol Action: class {
+public protocol Action: AnyObject {
 
     var control: UIControl { get }
 

--- a/Sources/MiKit/UI/Entry/Fields/FieldViewController.swift
+++ b/Sources/MiKit/UI/Entry/Fields/FieldViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import Resources
 import KeePassKit
 
-protocol FieldViewControllerDelegate: class {
+protocol FieldViewControllerDelegate: AnyObject {
     func fieldViewController(_ fieldViewController: FieldViewController, willUpdate attribute: KPKAttribute)
     func fieldViewController(_ fieldViewController: FieldViewController, didUpdate attribute: KPKAttribute)
     func fieldViewController(_ fieldViewController: FieldViewController, delete attribute: KPKAttribute)

--- a/Sources/MiKit/UI/OTP/QRScannerController.swift
+++ b/Sources/MiKit/UI/OTP/QRScannerController.swift
@@ -20,7 +20,7 @@ import UIKit
 import Resources
 
 /// Delegate callback for the QRScannerView.
-public protocol QRScannerControllerDelegate: class {
+public protocol QRScannerControllerDelegate: AnyObject {
     func scanner(_ scanner: QRScannerController, didFind code: String)
 }
 

--- a/Sources/MiKit/UI/OTP/QRScannerView.swift
+++ b/Sources/MiKit/UI/OTP/QRScannerView.swift
@@ -21,7 +21,7 @@ import UIKit
 import AVFoundation
 
 /// Delegate callback for the QRScannerView.
-public protocol QRScannerViewDelegate: class {
+public protocol QRScannerViewDelegate: AnyObject {
     func scanner(_ scanner: QRScannerView, DidFailWith error: Error)
     func scanner(_ scanner: QRScannerView, didFind code: String)
 }


### PR DESCRIPTION
Resolve warning "Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead".